### PR TITLE
Update map_to_g1.c

### DIFF
--- a/blst_src/map_to_g1.c
+++ b/blst_src/map_to_g1.c
@@ -332,7 +332,7 @@ static void map_to_isogenous_E1(POINTonE1 *p, const vec384 u)
     mul_fp(x1n, x1n, Bprime_E1);        /* x1n = x1n * B                */
     mul_fp(x2n, Zuu, x1n);              /* x2n = Zuu * x1n              */
 
-    /* x denumenator                                                    */
+    /* x denominator                                                    */
     mul_fp(xd, minus_A, tv2);           /* xd = -A * tv2                */
     e1 = vec_is_zero(xd, sizeof(xd));   /* e1 = xd == 0                 */
     vec_select(xd, ZxA, xd, sizeof(xd), e1);    /*              # If xd == 0, set xd = Z*A */


### PR DESCRIPTION


**Description:**
Corrects a spelling error in a comment within the map_to_isogenous_E1 function. The word "denumenator" was misspelled and has been corrected to "denominator". This is a simple documentation fix with no functional changes to the code.

The change affects:
- `blst_src/map_to_q1.c`
