### PR TITLE
Fix an issue with "bool" type def in recent versions

### DIFF
--- a/bls12381_utils.h
+++ b/bls12381_utils.h
@@ -29,14 +29,14 @@
 
 typedef uint8_t byte;
 
-#if !defined(__STDC_VERSION__) || __STDC_VERSION__<202311
+#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311
 typedef _Bool bool; /* it's assumed that cgo calls modern enough compiler */
-# elif !defined(bool)
-#  if defined(__STDC_VERSION__) && __STDC_VERSION__>=199901
-#   define bool _Bool
-#  else
-#   define bool int
-#  endif
+#elif !defined(bool)
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901
+#define bool _Bool
+#else
+#define bool int
+#endif
 #endif
 
 // minimum targeted security level


### PR DESCRIPTION
Fix an issue with `bool` type def in recent versions where `bool` is already defined.