### PR TITLE
Fix ECDSA P-256 private key construction panic on Go 1.26

### DIFF
--- a/ecdsa.go
+++ b/ecdsa.go
@@ -223,9 +223,19 @@ func goecdsaPrivateKey(curve elliptic.Curve, d *big.Int) (*ecdsa.PrivateKey, err
 
 	// compute the crypto/ecdsa public key
 	if curve == elliptic.P256() {
-		// use crypto/ecdh implementation to perform base scalar multiplication
-		// of an ECDH private key, because crypto/elliptic deprecated `ScalarBaseMult`
-		ecdhPriv, err := priv.ECDH()
+		// Perform the base scalar multiplication using crypto/ecdh,
+		// because crypto/elliptic deprecated `ScalarBaseMult`.
+		//
+		// We build the ecdh.PrivateKey directly from the scalar bytes
+		// instead of going through `priv.ECDH()`: since Go 1.26,
+		// ecdsa's `(*PrivateKey).ECDH` serializes the key via `(*PrivateKey).Bytes`,
+		// which reads the public affine coordinates `X`/`Y`.
+		// Those are not set yet at this point (we are computing them),
+		// so that path dereferences nil and panics.
+		// Constructing the ecdh key from the scalar avoids reading `X`/`Y`
+		// and works across Go versions.
+		scalarLen := bitsToBytes(curve.Params().N.BitLen())
+		ecdhPriv, err := ecdh.P256().NewPrivateKey(d.FillBytes(make([]byte, scalarLen)))
 		if err != nil {
 			// at this point, no error is expected because the function can't be called
 			// with a zero scalar modulo `n`


### PR DESCRIPTION
`goecdsaPrivateKey` called `priv.ECDH()` to derive the public point from the scalar, but the public affine coordinates `X`/`Y` are not set at that point.

Since Go 1.26, `(*ecdsa.PrivateKey).ECDH` serializes via `Bytes()`, which reads `X`/`Y` and panics on the `nil` coordinates.

Build the `ecdh.PrivateKey` directly from the scalar bytes instead, which avoids reading `X`/`Y`. Behavior is unchanged and compatible with Go 1.20+.